### PR TITLE
fix: Update import paths in ImportConfig to use dynamic output directory

### DIFF
--- a/packages/swagger_to_dart/lib/src/config/open_api_generator_config.dart
+++ b/packages/swagger_to_dart/lib/src/config/open_api_generator_config.dart
@@ -44,14 +44,20 @@ class ImportConfig {
 
   final BaseConfig baseConfig;
 
+  // The output directory for the generated code
+  // Example: 'lib/src/gen' will be replaced with '/src/gen'
+  String get _outputDirectory {
+    return baseConfig.swaggerToDart.outputDirectory.replaceFirst('lib', '');
+  }
+
   String get importModelsCode {
-    return '''import 'package:${baseConfig.pubspec.name}/src/gen/models/models.dart';
+    return '''import 'package:${baseConfig.pubspec.name + _outputDirectory}/models/models.dart';
     ${baseConfig.pubspec.isFlutterProject ? "import 'package:flutter/material.dart';" : ''} 
     ''';
   }
 
   String get importClientsCode {
-    return '''import 'package:${baseConfig.pubspec.name}/src/gen/clients/clients.dart';''';
+    return '''import 'package:${baseConfig.pubspec.name + _outputDirectory}/clients/clients.dart';''';
   }
 }
 


### PR DESCRIPTION
# Update Import Paths to Use Dynamic Output Directory

## Description
This PR fixes an issue with import paths by making them use dynamic output directory configuration. Previously, import paths were hardcoded ("src/gen") and did not properly respect the configured output directory, causing issues when users specified custom output locations.

## Changes
- Updated import path generation to use the configured output directory

## Why
These changes ensure that the tool works correctly regardless of where users choose to output their generated Dart files, improving flexibility and preventing broken imports in the generated code.

## Testing Done
- Verified imports work correctly with the default output directory
- Tested with custom output directory paths
- Confirmed imports between models and API files maintain correct paths

## Screenshots
<img width="400" alt="Screenshot 2025-04-16 at 9 55 28 PM" src="https://github.com/user-attachments/assets/bdf55e3e-2ac8-4900-80a1-5532c6d1654f" /><br>

<img width="400" alt="Screenshot 2025-04-16 at 9 54 26 PM" src="https://github.com/user-attachments/assets/a18dd3e8-4e97-4f57-b341-3ad6eb56a0a2" />