### PR TITLE
fix: update class and file name generation for API client to use cons…

### DIFF
--- a/packages/swagger_to_dart/lib/src/generator/api_client/api_client_generator.dart
+++ b/packages/swagger_to_dart/lib/src/generator/api_client/api_client_generator.dart
@@ -190,8 +190,8 @@ class ApiClientGenerator {
     required String clientName,
     required OpenApiPaths paths,
   }) {
-    final className = Renaming.instance.renameClass('${clientName}Client');
-    final fileName = Renaming.instance.renameFile(className);
+    final fileName = Renaming.instance.renameFile('${clientName}_client');
+    final className = Recase.instance.toPascalCase(fileName);
 
     return Library(
       (b) => b


### PR DESCRIPTION
fix #26 
<img width="375" alt="image" src="https://github.com/user-attachments/assets/7e6050c6-8f16-4ced-877f-44fc465a570e" />

![image](https://github.com/user-attachments/assets/5ac89729-2ed2-4859-b354-d386a61803d7)

The api_client_generator.dart uses the original Swagger class name (e.g., CMSCast), so the generated Dart class keeps the capital letters and becomes CMSCastClient. The corresponding file name becomes cms_cast_client.

However, in base_api_client_generator.dart, we was rely on the file name (cms_cast_client) to recreate the class name. This logic converts it to CmsCastClient instead of the correct CMSCastClient.

This pull request updates api_client_generator to first generate the file name, then use that file name to consistently recreate the class name. This ensures the class name remains correct and consistent across both generators.





