### PR TITLE
feat: add custom config file path support

### DIFF
--- a/packages/swagger_to_dart/bin/swagger_to_dart.dart
+++ b/packages/swagger_to_dart/bin/swagger_to_dart.dart
@@ -1,10 +1,15 @@
 import 'dart:io';
-
+import 'package:args/args.dart';
 import 'package:swagger_to_dart/swagger_to_dart.dart';
 
-Future<void> main() async {
+Future<void> main(List<String> arguments) async {
   try {
-    final builder = GenerationContextBuilder();
+    final parser = ArgParser()
+      ..addOption('config', abbr: 'c', help: 'Path to config file');
+    final argResults = parser.parse(arguments);
+    final configPath = argResults['config'] as String?;
+
+    final builder = GenerationContextBuilder(configPath: configPath);
     final GenerationContext context = await builder.build();
 
     final generator = SwaggerToDartCodeGenerator(context);

--- a/packages/swagger_to_dart/example/swagger_to_dart2.yaml
+++ b/packages/swagger_to_dart/example/swagger_to_dart2.yaml
@@ -1,0 +1,15 @@
+swagger_to_dart:
+  # url: http://0.0.0.0:8004/openapi.json
+  input_directory: schema/swagger.json
+  output_directory: lib/src/gen2
+
+  model:
+    support_generic_arguments: true
+    union_class_fallback_name: fallback
+    enum_fallback_type: first
+  api_client:
+    base_api_client_class_name: BaseApiClient
+    use_class_for_query_parameters: true
+    skipped_parameters:
+      - Language
+      - X-API-Key

--- a/packages/swagger_to_dart/pubspec.yaml
+++ b/packages/swagger_to_dart/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
 
   freezed_annotation: ^3.0.0
   json_annotation: ^4.9.0
+  args: ^2.7.0
 
 dev_dependencies:
   build_runner: ^2.4.13


### PR DESCRIPTION
add the ability to set a custom config file 
this will allow us to use many swagger file and generate a client for each one easily
usage example:
`dart run swagger_to_dart --config swagger_to_dart2.yaml  `