### PR TITLE
fix: update api client exports and file naming in swagger code generator

### DIFF
--- a/packages/swagger_to_dart/example/lib/main.dart
+++ b/packages/swagger_to_dart/example/lib/main.dart
@@ -8,7 +8,7 @@ Future<void> main(List<String> args) async {
 
   dio.options.baseUrl = 'http://0.0.0.0:8004';
 
-  final apiClient = BaseApiClient(dio);
+  final apiClient = FastApiClient(dio);
 
   final HttpResponse<BaseResponse<PaginationResponse<ItemResponse>>> response =
       await apiClient.genericClient.genericGetNestedBaseAndPagination(

--- a/packages/swagger_to_dart/example/lib/src/gen/api_client/api_client.dart
+++ b/packages/swagger_to_dart/example/lib/src/gen/api_client/api_client.dart
@@ -1,3 +1,4 @@
 library;
 
-export 'base_api_client.dart';
+export 'exports.dart';
+export 'fast_api_client.dart';

--- a/packages/swagger_to_dart/example/lib/src/gen/api_client/fast_api_client.dart
+++ b/packages/swagger_to_dart/example/lib/src/gen/api_client/fast_api_client.dart
@@ -9,8 +9,8 @@ import 'exports.dart';
 ///     "description": "Comprehensive examples of types and routes in FastAPI",
 ///     "version": "1.0.0"
 /// }
-class BaseApiClient {
-  BaseApiClient(this.dio, {this.baseUrl, this.errorLogger});
+class FastApiClient {
+  FastApiClient(this.dio, {this.baseUrl, this.errorLogger});
 
   final String? baseUrl;
 

--- a/packages/swagger_to_dart/example/lib/src/gen/gen.dart
+++ b/packages/swagger_to_dart/example/lib/src/gen/gen.dart
@@ -1,5 +1,4 @@
 library;
 
-export 'api_client/base_api_client.dart';
 export 'api_client/api_client.dart';
 export 'models/models.dart';

--- a/packages/swagger_to_dart/example/swagger_to_dart.yaml
+++ b/packages/swagger_to_dart/example/swagger_to_dart.yaml
@@ -8,7 +8,7 @@ swagger_to_dart:
     union_class_fallback_name: fallback
     enum_fallback_type: first
   api_client:
-    base_api_client_class_name: BaseApiClient
+    base_api_client_class_name: FastApiClient
     use_class_for_query_parameters: true
     skipped_parameters:
       - Language

--- a/packages/swagger_to_dart/lib/src/generator/swagger_to_dart_code_generator.dart
+++ b/packages/swagger_to_dart/lib/src/generator/swagger_to_dart_code_generator.dart
@@ -5,7 +5,6 @@ import 'package:dart_style/dart_style.dart';
 import 'package:path/path.dart' as path;
 import 'package:swagger_to_dart/src/config/generation_context.dart';
 import 'package:swagger_to_dart/src/generator/base_api_client_generator.dart';
-import 'package:swagger_to_dart/src/utils/utils.dart';
 
 class SwaggerToDartCodeGenerator {
   const SwaggerToDartCodeGenerator(this.context);
@@ -173,18 +172,19 @@ const jsonSerializable = JsonSerializable(
     );
 
     final baseApiCLientLibrary = BaseApiClientGenerator(context).build();
+    final baseApiCLientLibraryFileName = '${baseApiCLientLibrary.name}.dart';
 
     await writeDartLibraryFile(
-      path.join(apiClientsDir.path, '${baseApiCLientLibrary.name}.dart'),
+      path.join(apiClientsDir.path, baseApiCLientLibraryFileName),
       baseApiCLientLibrary,
     );
-    final fileName = Renaming.instance.renameFile(baseApiCLientLibrary.name!);
+
     final baseLibrary = Library(
       (b) => b
         ..name = 'api_client.dart'
         ..directives.addAll([
-          Directive.import('exports.dart'),
-          Directive.export('${fileName}.dart'),
+          Directive.export('exports.dart'),
+          Directive.export(baseApiCLientLibraryFileName),
         ]),
     );
 


### PR DESCRIPTION
Currently, setting a custom `base_api_client_class_name` results in an incorrect export name because it's hardcoded in two places.
This PR fixes it by using the correct file name in `api_client.dart` export, and removes the export from `gen.dart` as it's redundant — `api_client.dart` is already re-exported.
